### PR TITLE
Change: Refactors ucb_person_title to events-based

### DIFF
--- a/src/EventSubscriber/UcbPersonTitleSubscriber.php
+++ b/src/EventSubscriber/UcbPersonTitleSubscriber.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\ucb_person_title\EventSubscriber;
+
+use Drupal\core_event_dispatcher\Event\Form\FormAlterEvent;
+use Drupal\core_event_dispatcher\FormHookEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class UcbPersonTitleSubscriber.
+ *
+ * 
+ * "event_subscriber" needs to be in the *.services.yml:
+ * like so...
+ * services:
+ *   ucb_person_title.event_subscriber:
+ *     class: Drupal\ucb_person_title\EventSubscriber\UcbPersonTitleSubscriber
+ *     tags:
+ *       - { name: event_subscriber }
+ */
+class UcbPersonTitleSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      FormHookEvents::FORM_ALTER => 'alterUcbPersonForm',
+    ];
+  }
+
+  /**
+   * Alter ucb_person form.
+   *
+   * @param \Drupal\core_event_dispatcher\Event\Form\FormAlterEvent $event
+   *   The form alter event.
+   */
+  public function alterUcbPersonForm(FormAlterEvent $event): void {
+    $form = &$event->getForm();
+    $form_id = $event->getFormId();
+
+    if ($form_id === 'node_ucb_person_form' || $form_id === 'node_ucb_person_edit_form') {
+      $form['title']['#access'] = FALSE;
+      $form['#entity_builders'][] = 'Drupal\ucb_person_title\EventSubscriber\UcbPersonTitleSubscriber::ucbPersonTitleBuilder';
+    }
+  }
+
+  /**
+   * Custom entity builder for ucb_person.
+   *
+   * @param string $entity_type
+   *   The entity type.
+   * @param \Drupal\node\Entity\Node $node
+   *   The node entity.
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function ucbPersonTitleBuilder(string $entity_type, $node, array &$form, FormStateInterface $form_state): void {
+    $last = $node->get('field_ucb_person_last_name')->value;
+    $first = $node->get('field_ucb_person_first_name')->value;
+    $node->setTitle($first . ' ' . $last);
+  }
+}

--- a/ucb_person_title.info.yml
+++ b/ucb_person_title.info.yml
@@ -1,12 +1,13 @@
 name: UCB Person Title
 description: 'Programatically generates a Person Page title on creation using First and Last Name fields'
 type: module
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^8.9 || ^9 || ^10'
 dependencies:
   - file
   - field
   - image
   - system
+  - drupal:hook_event_dispatcher
 
 version: '1.0.0'
 package: 'UCB Person Title'

--- a/ucb_person_title.module
+++ b/ucb_person_title.module
@@ -1,48 +1,5 @@
 <?php
 
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\NodeInterface;
- 
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * @param $form
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- * @param $form_id
- */
-
- // Handles Person Page creation
-function ucb_person_title_form_node_ucb_person_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-    $form['title']['#access'] = FALSE;
-    $form['#entity_builders'][] = 'ucb_person_title_builder';
-}
-
-// Handles Person Page edit form
-function ucb_person_title_form_node_ucb_person_edit_form_alter(&$form, FormStateInterface $form_state, $form_id){
-  $form['title']['#access'] = FALSE;
-  $form['#entity_builders'][] = 'ucb_person_title_builder';
-}
- 
-/**
- * Title builder for Person Page & Person Page Edit Form.
- *
- * @param $entity_type
- * @param \Drupal\node\NodeInterface $node
- * @param $form
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- */
-function ucb_person_title_builder($entity_type, NodeInterface $node, $form, FormStateInterface $form_state) {
-  $last = $node->get('field_ucb_person_last_name')->value;
-  $first = $node->get('field_ucb_person_first_name')->value;
-
-  // Remove whitespace
-  $last = str_replace(' ', '', $last);
-  $first = str_replace(' ', '', $first);
- 
-  // Set title
-  $node->setTitle( $first . ' ' . $last);
-}
-
-?>
-
-
+// This file can be left empty since the logic has been moved to the 
+// UcbPersonTitleEventSubscriber class using the events system.
+// use Drupal\Core\Routing\RouteMatchInterface;

--- a/ucb_person_title.services.yml
+++ b/ucb_person_title.services.yml
@@ -1,0 +1,5 @@
+services:
+  ucb_person_title.event_subscriber:
+    class: Drupal\ucb_person_title\EventSubscriber\UcbPersonTitleSubscriber
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
Some hooks in custom modules break focal point functionality due to a bug in Core. With this change, the focal point preview on Person pages still works while allowing additional functionality needed via custom modules such as hiding the title and allowing the title to be created using a Person's First and Last Name fields. 

Includes:

- `tiamat10-project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/14
-  `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/27
- `ucb_person_title` => https://github.com/CuBoulder/ucb_person_title/pull/3

Resolves https://github.com/CuBoulder/ucb_person_title/issues/2, Resolves https://github.com/CuBoulder/tiamat-theme/issues/220