### PR TITLE
Fixes UCB Person Page Custom Modules

### DIFF
--- a/ucb_person_title.info.yml
+++ b/ucb_person_title.info.yml
@@ -1,7 +1,7 @@
 name: UCB Person Title
 description: 'Programatically generates a Person Page title on creation using First and Last Name fields'
 type: module
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^8.9 || ^9 || ^10'
 dependencies:
   - file
   - field

--- a/ucb_person_title.info.yml
+++ b/ucb_person_title.info.yml
@@ -1,7 +1,7 @@
 name: UCB Person Title
 description: 'Programatically generates a Person Page title on creation using First and Last Name fields'
 type: module
-core_version_requirement: '^8.9 || ^9 || ^10'
+core_version_requirement: '^9 || ^10'
 dependencies:
   - file
   - field

--- a/ucb_person_title.module
+++ b/ucb_person_title.module
@@ -10,8 +10,6 @@ use Drupal\node\NodeInterface;
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  * @param $form_id
  */
-
- // Handles Person Page creation
 function ucb_person_title_form_node_ucb_person_form_alter(&$form, FormStateInterface $form_state, $form_id) {
     $form['title']['#access'] = FALSE;
     $form['#entity_builders'][] = 'ucb_person_title_builder';
@@ -42,7 +40,3 @@ function ucb_person_title_builder($entity_type, NodeInterface $node, $form, Form
   // Set title
   $node->setTitle( $first . ' ' . $last);
 }
-
-?>
-
-

--- a/ucb_person_title.module
+++ b/ucb_person_title.module
@@ -34,8 +34,8 @@ function ucb_person_title_builder($entity_type, NodeInterface $node, $form, Form
   $first = $node->get('field_ucb_person_first_name')->value;
 
   // Remove whitespace
-  $last = str_replace(' ', '', $last);
-  $first = str_replace(' ', '', $first);
+  $last = trim($last);
+  $first = trim($first);
  
   // Set title
   $node->setTitle( $first . ' ' . $last);


### PR DESCRIPTION
Adds the fixed versions of `UCB Person Title` and `UCB Article Author` to template and profile. Allows First and Last Name fields to create a Person Page title, getting rid of the need to enter a title for these pages. Also automatically creates a Byline taxonomy for newly created Person Pages, for use in the Byline field. 

Includes:

- `tiamat10-project-template` => https://github.com/CuBoulder/tiamat10-project-template/pull/15 (`issue/ucb_person_title/2`)
-  `tiamat-profile` => https://github.com/CuBoulder/tiamat10-profile/pull/28 (`issue/ucb_person_title/2`)
-  `ucb_person_title` => https://github.com/CuBoulder/ucb_person_title/pull/4 (`issue/2`)
-  `ucb_article_author` => https://github.com/CuBoulder/ucb_article_author/pull/2 (`issue/1`)

Resolves https://github.com/CuBoulder/ucb_article_author/issues/1, Resolves https://github.com/CuBoulder/ucb_person_title/issues/2